### PR TITLE
优化 Codex 本地会话阅读体验：改进布局、提问导航、过程消息过滤与目录记忆

### DIFF
--- a/index.html
+++ b/index.html
@@ -1210,7 +1210,7 @@ dd {
   border-color: color-mix(in srgb, var(--accent), transparent 82%);
 }
 
-.conversation-item.reasoning {
+.conversation-item.commentary {
   margin-inline: clamp(14px, 4vw, 72px);
   background: color-mix(in srgb, var(--warning-soft), var(--surface-strong) 32%);
   border-color: color-mix(in srgb, var(--warning), transparent 70%);
@@ -1228,7 +1228,7 @@ dd {
   background: color-mix(in srgb, var(--accent), transparent 18%);
 }
 
-.conversation-item.reasoning::before {
+.conversation-item.commentary::before {
   background: var(--warning);
 }
 
@@ -1266,7 +1266,7 @@ dd {
   color: var(--text);
 }
 
-.conversation-item.reasoning .conversation-role {
+.conversation-item.commentary .conversation-role {
   background: color-mix(in srgb, var(--warning-soft), var(--surface-strong) 14%);
   border-color: color-mix(in srgb, var(--warning), transparent 68%);
   color: color-mix(in srgb, var(--warning), var(--text) 24%);
@@ -1626,7 +1626,7 @@ dd {
 
   .conversation-item.user,
   .conversation-item.assistant,
-  .conversation-item.reasoning {
+  .conversation-item.commentary {
     margin-left: 0;
     margin-right: 0;
   }
@@ -1878,8 +1878,8 @@ dd {
 	                  <span id="detail-message-count" class="badge">0</span>
 	                </div>
 	                <label class="checkbox-row detail-inline-toggle">
-	                  <input id="reasoning-toggle" type="checkbox" />
-	                  <span id="reasoning-toggle-label">显示思考摘要</span>
+	                  <input id="commentary-toggle" type="checkbox" />
+	                  <span id="commentary-toggle-label">显示过程消息</span>
 	                </label>
 	              </div>
 	              <div id="detail-preview" class="conversation-stream">
@@ -2001,7 +2001,11 @@ dd {
     <script type="module">
 const THEME_STORAGE_KEY = "codex-session-console-theme";
 const LOCALE_STORAGE_KEY = "codex-session-console-locale";
-const REASONING_VISIBILITY_STORAGE_KEY = "codex-session-console-show-reasoning";
+const COMMENTARY_VISIBILITY_STORAGE_KEY = "codex-session-console-show-commentary";
+const HANDLE_DB_NAME = "codex-session-console";
+const HANDLE_DB_VERSION = 1;
+const HANDLE_STORE_NAME = "handles";
+const ROOT_HANDLE_STORAGE_KEY = "root-directory";
 const REPOSITORY_URL = "https://github.com/zhengshuyun-com/codex-local-session-manager";
 
 const I18N = {
@@ -2098,7 +2102,7 @@ const I18N = {
       loading: "加载中.",
       statusNormal: "正常",
       statusStale: "脏索引",
-      showReasoning: "显示思考摘要",
+      showCommentary: "显示过程消息",
     },
     modal: {
       titleAll: "确认删除全部会话",
@@ -2137,7 +2141,7 @@ const I18N = {
     timeline: {
       user: "用户",
       assistant: "Codex",
-      reasoning: "思考摘要",
+      commentary: "过程消息",
       toolCall: "工具调用",
       toolOutput: "工具输出",
       historyInput: "历史输入 #{{index}}",
@@ -2251,7 +2255,7 @@ const I18N = {
       loading: "Loading.",
       statusNormal: "Normal",
       statusStale: "Stale index",
-      showReasoning: "Show reasoning summaries",
+      showCommentary: "Show progress updates",
     },
     modal: {
       titleAll: "Confirm delete all sessions",
@@ -2291,7 +2295,7 @@ const I18N = {
     timeline: {
       user: "User",
       assistant: "Codex",
-      reasoning: "Reasoning Summary",
+      commentary: "Progress",
       toolCall: "Tool call",
       toolOutput: "Tool output",
       historyInput: "History input #{{index}}",
@@ -2329,7 +2333,7 @@ const state = {
   pageSize: 10,
   locale: "zh-CN",
   themeMode: "light",
-  showReasoning: false,
+  showCommentary: false,
   modalKind: null,
   pendingActionMode: null,
   countdownRemaining: 0,
@@ -2373,8 +2377,8 @@ const elements = {
   detailPreviewTitle: document.querySelector("#detail-preview-title"),
   detailPreview: document.querySelector("#detail-preview"),
   detailMessageCount: document.querySelector("#detail-message-count"),
-  reasoningToggle: document.querySelector("#reasoning-toggle"),
-  reasoningToggleLabel: document.querySelector("#reasoning-toggle-label"),
+  commentaryToggle: document.querySelector("#commentary-toggle"),
+  commentaryToggleLabel: document.querySelector("#commentary-toggle-label"),
   downloadCurrentButton: document.querySelector("#download-current-button"),
   deleteCurrentButton: document.querySelector("#delete-current-button"),
   repoLink: document.querySelector("#repo-link"),
@@ -2416,7 +2420,7 @@ function initialize() {
   elements.prevPageButton.addEventListener("click", () => changePage(-1));
   elements.nextPageButton.addEventListener("click", () => changePage(1));
   elements.detailOutline.addEventListener("click", handleOutlineJump);
-  elements.reasoningToggle.addEventListener("change", handleReasoningToggleChange);
+  elements.commentaryToggle.addEventListener("change", handleCommentaryToggleChange);
   elements.downloadCurrentButton.addEventListener("click", () => downloadCurrentSession().catch(handleError));
   elements.deleteCurrentButton.addEventListener("click", () => openConfirmDialog("single"));
   elements.modalBackdrop.addEventListener("click", handleModalDismiss);
@@ -2427,18 +2431,161 @@ function initialize() {
 
   applyLocale(getInitialLocale());
   applyTheme(getInitialThemeMode());
-  applyReasoningVisibility(getInitialReasoningVisibility(), { rerender: false });
+  applyCommentaryVisibility(getInitialCommentaryVisibility(), { rerender: false });
   renderEmptyList(t("list.unscanned"));
   renderDetails(null);
   updateStatus();
+
+  if (isSupported) {
+    restorePersistedDirectory().catch((error) => {
+      console.warn("Failed to restore previously selected directory.", error);
+    });
+  }
+}
+
+function requestToPromise(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error("IndexedDB request failed."));
+  });
+}
+
+function transactionDone(transaction) {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(transaction.error || new Error("IndexedDB transaction aborted."));
+    transaction.onerror = () => reject(transaction.error || new Error("IndexedDB transaction failed."));
+  });
+}
+
+async function openHandleDatabase() {
+  if (typeof indexedDB === "undefined") {
+    return null;
+  }
+
+  const request = indexedDB.open(HANDLE_DB_NAME, HANDLE_DB_VERSION);
+  request.onupgradeneeded = () => {
+    const database = request.result;
+
+    if (!database.objectStoreNames.contains(HANDLE_STORE_NAME)) {
+      database.createObjectStore(HANDLE_STORE_NAME);
+    }
+  };
+
+  return requestToPromise(request);
+}
+
+function isDirectoryHandle(handle) {
+  return Boolean(handle && handle.kind === "directory" && typeof handle.getDirectoryHandle === "function");
+}
+
+async function getPersistedRootHandle() {
+  const database = await openHandleDatabase();
+
+  if (!database) {
+    return null;
+  }
+
+  try {
+    const transaction = database.transaction(HANDLE_STORE_NAME, "readonly");
+    const request = transaction.objectStore(HANDLE_STORE_NAME).get(ROOT_HANDLE_STORAGE_KEY);
+    const [handle] = await Promise.all([requestToPromise(request), transactionDone(transaction)]);
+    return isDirectoryHandle(handle) ? handle : null;
+  } finally {
+    database.close();
+  }
+}
+
+async function persistRootHandle(handle) {
+  if (!isDirectoryHandle(handle)) {
+    return;
+  }
+
+  const database = await openHandleDatabase();
+
+  if (!database) {
+    return;
+  }
+
+  try {
+    const transaction = database.transaction(HANDLE_STORE_NAME, "readwrite");
+    transaction.objectStore(HANDLE_STORE_NAME).put(handle, ROOT_HANDLE_STORAGE_KEY);
+    await transactionDone(transaction);
+  } finally {
+    database.close();
+  }
+}
+
+async function clearPersistedRootHandle() {
+  const database = await openHandleDatabase();
+
+  if (!database) {
+    return;
+  }
+
+  try {
+    const transaction = database.transaction(HANDLE_STORE_NAME, "readwrite");
+    transaction.objectStore(HANDLE_STORE_NAME).delete(ROOT_HANDLE_STORAGE_KEY);
+    await transactionDone(transaction);
+  } finally {
+    database.close();
+  }
+}
+
+async function queryHandlePermission(handle, mode = "read") {
+  if (!handle || typeof handle.queryPermission !== "function") {
+    return "prompt";
+  }
+
+  try {
+    return await handle.queryPermission({ mode });
+  } catch {
+    return "prompt";
+  }
+}
+
+async function restorePersistedDirectory() {
+  const rootHandle = await getPersistedRootHandle();
+
+  if (!rootHandle) {
+    return false;
+  }
+
+  if ((await queryHandlePermission(rootHandle, "read")) !== "granted") {
+    return false;
+  }
+
+  try {
+    const sessionsDirHandle = await rootHandle.getDirectoryHandle("sessions");
+    state.rootHandle = rootHandle;
+    state.sessionsDirHandle = sessionsDirHandle;
+    elements.reloadButton.disabled = false;
+    await scanSessions();
+    return true;
+  } catch (error) {
+    if (error?.name === "NotFoundError") {
+      await clearPersistedRootHandle();
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 async function pickDirectoryFromSystem() {
   try {
     const rootHandle = await window.showDirectoryPicker({ mode: "readwrite" });
+    const sessionsDirHandle = await rootHandle.getDirectoryHandle("sessions");
     state.rootHandle = rootHandle;
-    state.sessionsDirHandle = await rootHandle.getDirectoryHandle("sessions");
+    state.sessionsDirHandle = sessionsDirHandle;
     elements.reloadButton.disabled = false;
+
+    try {
+      await persistRootHandle(rootHandle);
+    } catch (error) {
+      console.warn("Failed to persist selected directory.", error);
+    }
+
     await scanSessions();
   } catch (error) {
     if (error?.name === "AbortError") {
@@ -2649,14 +2796,14 @@ function changePage(offset) {
   updateStatus();
 }
 
-function handleReasoningToggleChange() {
-  applyReasoningVisibility(elements.reasoningToggle.checked);
+function handleCommentaryToggleChange() {
+  applyCommentaryVisibility(elements.commentaryToggle.checked);
 }
 
-function applyReasoningVisibility(visible, { rerender = true } = {}) {
-  state.showReasoning = Boolean(visible);
-  localStorage.setItem(REASONING_VISIBILITY_STORAGE_KEY, state.showReasoning ? "1" : "0");
-  elements.reasoningToggle.checked = state.showReasoning;
+function applyCommentaryVisibility(visible, { rerender = true } = {}) {
+  state.showCommentary = Boolean(visible);
+  localStorage.setItem(COMMENTARY_VISIBILITY_STORAGE_KEY, state.showCommentary ? "1" : "0");
+  elements.commentaryToggle.checked = state.showCommentary;
 
   if (!rerender) {
     return;
@@ -2672,8 +2819,8 @@ function applyReasoningVisibility(visible, { rerender = true } = {}) {
   renderTimelinePanels(activeSession).catch(handleError);
 }
 
-function getInitialReasoningVisibility() {
-  return localStorage.getItem(REASONING_VISIBILITY_STORAGE_KEY) === "1";
+function getInitialCommentaryVisibility() {
+  return localStorage.getItem(COMMENTARY_VISIBILITY_STORAGE_KEY) === "1";
 }
 
 function applyFilters() {
@@ -2903,7 +3050,7 @@ function renderDetails(session) {
     elements.detailPreviewTitle.textContent = t("section.conversation");
     setBadgeText(elements.detailMessageCount, "0");
     elements.detailPreview.innerHTML = `<p class="empty-state">${escapeHtml(t("detail.noContent"))}</p>`;
-    elements.reasoningToggle.disabled = true;
+    elements.commentaryToggle.disabled = true;
     elements.downloadCurrentButton.disabled = true;
     elements.downloadCurrentButton.textContent = t("buttons.download");
     elements.deleteCurrentButton.disabled = true;
@@ -2920,7 +3067,7 @@ function renderDetails(session) {
   ].join("");
   elements.detailOutlineTitle.textContent = t("section.questions");
   elements.detailPreviewTitle.textContent = t("section.conversation");
-  elements.reasoningToggle.disabled = false;
+  elements.commentaryToggle.disabled = false;
   elements.downloadCurrentButton.disabled = !isSessionDownloadable(session);
   elements.downloadCurrentButton.textContent = t("buttons.download");
   elements.deleteCurrentButton.disabled = !isSessionDeletable(session);
@@ -3070,7 +3217,7 @@ function getTimelineDedupeKey(item) {
     return "";
   }
 
-  if (item.kind !== "user" && item.kind !== "assistant") {
+  if (!["user", "assistant", "commentary"].includes(item.kind)) {
     return "";
   }
 
@@ -3145,12 +3292,29 @@ function stripTimelineMeta(item) {
   };
 }
 
-function extractEventMessageItems(record) {
-  const eventType = record.payload?.type;
-  const timestamp = record.timestamp || record.payload?.timestamp || null;
+function getAssistantTimelineKind(phase) {
+  return phase === "commentary" ? "commentary" : "assistant";
+}
 
-  if (eventType === "user_message" && record.payload?.message) {
-    const body = sanitizeConversationBody(record.payload.message, "user");
+function getTimelineRoleLabel(kind) {
+  if (kind === "user") {
+    return t("timeline.user");
+  }
+
+  if (kind === "commentary") {
+    return t("timeline.commentary");
+  }
+
+  return t("timeline.assistant");
+}
+
+function extractEventMessageItems(record) {
+  const payload = record.payload || {};
+  const eventType = payload.type;
+  const timestamp = record.timestamp || payload.timestamp || null;
+
+  if (eventType === "user_message" && payload.message) {
+    const body = sanitizeConversationBody(payload.message, "user");
 
     if (!body) {
       return [];
@@ -3166,8 +3330,9 @@ function extractEventMessageItems(record) {
     ];
   }
 
-  if (eventType === "agent_message" && record.payload?.message) {
-    const body = sanitizeConversationBody(record.payload.message, "assistant");
+  if (eventType === "agent_message" && payload.message) {
+    const kind = getAssistantTimelineKind(payload.phase);
+    const body = sanitizeConversationBody(payload.message, "assistant");
 
     if (!body) {
       return [];
@@ -3175,8 +3340,8 @@ function extractEventMessageItems(record) {
 
     return [
       {
-        kind: "assistant",
-        roleLabel: t("timeline.assistant"),
+        kind,
+        roleLabel: getTimelineRoleLabel(kind),
         timestamp,
         body,
       },
@@ -3197,29 +3362,16 @@ function extractResponseItems(record) {
       return [];
     }
 
+    const kind = payload.role === "user" ? "user" : getAssistantTimelineKind(payload.phase);
+
     return [
       {
-        kind: payload.role === "user" ? "user" : "assistant",
-        roleLabel: payload.role === "user" ? t("timeline.user") : t("timeline.assistant"),
+        kind,
+        roleLabel: getTimelineRoleLabel(kind),
         timestamp,
         body,
       },
     ];
-  }
-
-  if (payload.type === "reasoning") {
-    const body = extractReasoningSummary(payload);
-
-    return body
-      ? [
-          {
-            kind: "reasoning",
-            roleLabel: t("timeline.reasoning"),
-            timestamp,
-            body,
-          },
-        ]
-      : [];
   }
 
   return [];
@@ -3248,39 +3400,6 @@ function extractMessageContent(content, role = "") {
     .trim();
 
   return sanitizeConversationBody(text, role);
-}
-
-function extractReasoningSummary(payload) {
-  const summary = Array.isArray(payload.summary) ? payload.summary : [];
-  const summaryText = summary
-    .map((item) => {
-      if (item?.type === "summary_text") {
-        return item.text || "";
-      }
-
-      return typeof item === "string" ? item : "";
-    })
-    .map((text) => normalizeReasoningSummaryText(text))
-    .filter(Boolean)
-    .join("\n\n")
-    .trim();
-
-  if (summaryText) {
-    return summaryText;
-  }
-
-  if (Array.isArray(payload.content)) {
-    return normalizeReasoningSummaryText(extractMessageContent(payload.content, "assistant"));
-  }
-
-  return "";
-}
-
-function normalizeReasoningSummaryText(text) {
-  return String(text || "")
-    .replace(/\*\*(.*?)\*\*/g, "$1")
-    .replace(/__(.*?)__/g, "$1")
-    .trim();
 }
 
 function buildFallbackTimeline(session) {
@@ -3332,7 +3451,7 @@ function renderQuestionOutlineItem(item) {
 }
 
 function getVisibleTimelineItems(timeline) {
-  return timeline.filter((item) => item.kind !== "reasoning" || state.showReasoning);
+  return timeline.filter((item) => item.kind !== "commentary" || state.showCommentary);
 }
 
 function finalizeTimeline(items) {
@@ -3363,7 +3482,7 @@ function getOutlineTitle(body) {
 }
 
 function isRenderableTimelineItem(item) {
-  return ["user", "assistant", "reasoning"].includes(item.kind) && Boolean(item.body?.trim());
+  return ["user", "assistant", "commentary"].includes(item.kind) && Boolean(item.body?.trim());
 }
 
 function sanitizeConversationBody(body, kind) {
@@ -3891,7 +4010,7 @@ function applyLocale(locale) {
   setText(document.querySelector("#detail-section-title"), t("section.detail"));
   setText(document.querySelector("#detail-overview-default-label"), t("labels.sessionId"));
   setText(elements.detailOutlineTitle, t("section.questions"));
-  setText(elements.reasoningToggleLabel, t("detail.showReasoning"));
+  setText(elements.commentaryToggleLabel, t("detail.showCommentary"));
   setText(elements.pickDirectoryButton, t("buttons.pickDirectory"));
   setText(elements.reloadButton, t("buttons.reload"));
   setText(elements.deleteSelectedButton, t("buttons.deleteSelected"));
@@ -3901,8 +4020,8 @@ function applyLocale(locale) {
   setText(elements.nextPageButton, t("buttons.nextPage"));
   setText(elements.downloadCurrentButton, t("buttons.download"));
   setText(elements.modalCancelButton, t("buttons.cancel"));
-  elements.reasoningToggle.setAttribute("aria-label", t("detail.showReasoning"));
-  elements.reasoningToggle.setAttribute("title", t("detail.showReasoning"));
+  elements.commentaryToggle.setAttribute("aria-label", t("detail.showCommentary"));
+  elements.commentaryToggle.setAttribute("title", t("detail.showCommentary"));
   elements.repoLink.setAttribute("aria-label", t("buttons.repository"));
   elements.repoLink.setAttribute("title", t("buttons.repository"));
 

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@ p {
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow);
-  backdrop-filter: blur(14px);
+  backdrop-filter: blur(8px);
 }
 
 .hero {
@@ -288,8 +288,8 @@ h1 {
 
 .bottom-panels {
   display: grid;
-  grid-template-columns: minmax(0, 1.06fr) minmax(340px, 0.84fr);
-  gap: 12px;
+  grid-template-columns: minmax(280px, 0.84fr) minmax(0, 1.32fr);
+  gap: 14px;
   min-height: 0;
 }
 
@@ -801,6 +801,9 @@ dd {
   min-height: 0;
   overflow-y: auto;
   padding-right: 4px;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  contain: layout paint;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
@@ -832,7 +835,7 @@ dd {
 .detail-scroll {
   display: grid;
   align-content: start;
-  gap: 14px;
+  gap: 16px;
 }
 
 .session-list,
@@ -855,6 +858,9 @@ dd {
   border: 1px solid var(--border);
   background: var(--surface-soft);
   padding: 8px;
+  content-visibility: auto;
+  contain: layout paint style;
+  contain-intrinsic-size: 116px;
   transition:
     border-color 180ms ease,
     background-color 180ms ease,
@@ -880,6 +886,7 @@ dd {
   background: transparent;
   color: inherit;
   text-align: left;
+  min-width: 0;
 }
 
 .group-pills {
@@ -992,6 +999,12 @@ dd {
   .workspace {
     overflow: hidden;
   }
+
+  .list-surface,
+  .detail-surface {
+    background: var(--surface-strong);
+    backdrop-filter: none;
+  }
 }
 
 @media (min-width: 1041px) and (max-height: 759px) {
@@ -1036,6 +1049,10 @@ dd {
   gap: 10px;
 }
 
+#detail-overview {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 .preview-item,
 .empty-state {
   border-radius: var(--radius-lg);
@@ -1044,25 +1061,57 @@ dd {
   padding: 12px 14px;
 }
 
+.conversation-stream {
+  gap: 14px;
+}
+
 .conversation-item {
+  position: relative;
+  max-width: min(100%, 58rem);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   background: var(--surface-soft);
-  padding: 12px 14px;
+  padding: 14px 16px 14px 22px;
   display: grid;
-  gap: 8px;
+  gap: 10px;
+  content-visibility: auto;
+  contain: layout paint style;
+  contain-intrinsic-size: 180px;
+}
+
+.conversation-item::before {
+  content: "";
+  position: absolute;
+  top: 14px;
+  bottom: 14px;
+  left: 10px;
+  width: 4px;
+  border-radius: 999px;
+  background: transparent;
 }
 
 .conversation-item.user {
-  border-color: color-mix(in srgb, var(--accent), transparent 78%);
+  margin-left: clamp(20px, 6vw, 92px);
+  background: color-mix(in srgb, var(--info-soft), var(--surface-strong) 34%);
+  border-color: color-mix(in srgb, var(--info), transparent 72%);
 }
 
 .conversation-item.assistant {
-  border-color: var(--border-strong);
+  margin-right: clamp(16px, 4vw, 64px);
+  background: color-mix(in srgb, var(--surface-strong), var(--bg-elevated) 16%);
+  border-color: color-mix(in srgb, var(--accent), transparent 82%);
 }
 
 .conversation-item.system {
   background: color-mix(in srgb, var(--surface-soft), transparent 15%);
+}
+
+.conversation-item.user::before {
+  background: var(--info);
+}
+
+.conversation-item.assistant::before {
+  background: color-mix(in srgb, var(--accent), transparent 18%);
 }
 
 .conversation-meta {
@@ -1087,9 +1136,22 @@ dd {
   font-size: 0.76rem;
 }
 
+.conversation-item.user .conversation-role {
+  background: color-mix(in srgb, var(--info-soft), var(--surface-strong) 18%);
+  border-color: color-mix(in srgb, var(--info), transparent 68%);
+  color: color-mix(in srgb, var(--info), var(--text) 18%);
+}
+
+.conversation-item.assistant .conversation-role {
+  background: color-mix(in srgb, var(--surface-strong), var(--bg-elevated) 10%);
+  border-color: color-mix(in srgb, var(--accent), transparent 82%);
+  color: var(--text);
+}
+
 .conversation-body {
   color: var(--text);
-  line-height: 1.55;
+  line-height: 1.7;
+  font-size: 0.95rem;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -1336,7 +1398,7 @@ dd {
   }
 
   .bottom-panels {
-    grid-template-columns: minmax(0, 1fr) minmax(320px, 0.92fr);
+    grid-template-columns: minmax(280px, 0.76fr) minmax(0, 1.24fr);
   }
 }
 
@@ -1426,6 +1488,16 @@ dd {
     justify-content: space-between;
     width: 100%;
     padding-left: 0;
+  }
+
+  #detail-overview {
+    grid-template-columns: 1fr;
+  }
+
+  .conversation-item.user,
+  .conversation-item.assistant {
+    margin-left: 0;
+    margin-right: 0;
   }
 }
 
@@ -1781,7 +1853,6 @@ dd {
 const THEME_STORAGE_KEY = "codex-session-console-theme";
 const LOCALE_STORAGE_KEY = "codex-session-console-locale";
 const REPOSITORY_URL = "https://github.com/zhengshuyun-com/codex-local-session-manager";
-const TOOL_OUTPUT_LIMIT = 600;
 
 const I18N = {
   "zh-CN": {
@@ -2310,15 +2381,16 @@ async function readHistoryIndex(rootHandle) {
 
     for (const line of splitJsonLines(text)) {
       const parsed = safeJsonParse(line);
+      const cleanedText = sanitizeConversationBody(parsed?.text, "user");
 
-      if (!parsed?.session_id || typeof parsed.text !== "string" || !parsed.text.trim()) {
+      if (!parsed?.session_id || !cleanedText) {
         continue;
       }
 
       const list = records.get(parsed.session_id) || [];
 
       if (list.length < 3) {
-        list.push(parsed.text.trim());
+        list.push(cleanedText);
         records.set(parsed.session_id, list);
       }
     }
@@ -2697,7 +2769,9 @@ async function getSessionTimeline(session) {
     }
   }
 
-  const timeline = items.length ? dedupePreviewTimeline(items).map(stripTimelineMeta) : buildFallbackTimeline(session);
+  const timeline = items.length
+    ? dedupePreviewTimeline(items).map(stripTimelineMeta).filter(isRenderableTimelineItem)
+    : buildFallbackTimeline(session);
   state.timelineCache.set(session.id, timeline);
   return timeline;
 }
@@ -2823,23 +2897,35 @@ function extractEventMessageItems(record) {
   const timestamp = record.timestamp || record.payload?.timestamp || null;
 
   if (eventType === "user_message" && record.payload?.message) {
+    const body = sanitizeConversationBody(record.payload.message, "user");
+
+    if (!body) {
+      return [];
+    }
+
     return [
       {
         kind: "user",
         roleLabel: t("timeline.user"),
         timestamp,
-        body: record.payload.message.trim(),
+        body,
       },
     ];
   }
 
   if (eventType === "agent_message" && record.payload?.message) {
+    const body = sanitizeConversationBody(record.payload.message, "assistant");
+
+    if (!body) {
+      return [];
+    }
+
     return [
       {
         kind: "assistant",
         roleLabel: t("timeline.assistant"),
         timestamp,
-        body: record.payload.message.trim(),
+        body,
       },
     ];
   }
@@ -2852,7 +2938,7 @@ function extractResponseItems(record) {
   const timestamp = record.timestamp || payload.timestamp || null;
 
   if (payload.type === "message" && (payload.role === "user" || payload.role === "assistant")) {
-    const body = extractMessageContent(payload.content);
+    const body = extractMessageContent(payload.content, payload.role);
 
     if (!body) {
       return [];
@@ -2868,45 +2954,15 @@ function extractResponseItems(record) {
     ];
   }
 
-  if (payload.type === "function_call" || payload.type === "custom_tool_call") {
-    const body = summarizeToolInvocation(payload);
-
-    return body
-      ? [
-          {
-            kind: "system",
-            roleLabel: t("timeline.toolCall"),
-            timestamp,
-            body,
-          },
-        ]
-      : [];
-  }
-
-  if (payload.type === "function_call_output" || payload.type === "custom_tool_call_output") {
-    const body = summarizeToolOutput(payload);
-
-    return body
-      ? [
-          {
-            kind: "system",
-            roleLabel: t("timeline.toolOutput"),
-            timestamp,
-            body,
-          },
-        ]
-      : [];
-  }
-
   return [];
 }
 
-function extractMessageContent(content) {
+function extractMessageContent(content, role = "") {
   if (!Array.isArray(content)) {
     return "";
   }
 
-  return content
+  const text = content
     .map((item) => {
       if (item.type === "input_text" || item.type === "output_text") {
         return item.text || "";
@@ -2922,32 +2978,13 @@ function extractMessageContent(content) {
     .filter(Boolean)
     .join("\n\n")
     .trim();
-}
 
-function summarizeToolInvocation(payload) {
-  const name = payload.name || t("timeline.toolCall");
-  const args = typeof payload.arguments === "string" ? payload.arguments.trim() : "";
-
-  if (!args) {
-    return name;
-  }
-
-  return `${name}\n${truncateText(args, TOOL_OUTPUT_LIMIT)}`;
-}
-
-function summarizeToolOutput(payload) {
-  const output = typeof payload.output === "string" ? payload.output.trim() : "";
-
-  if (!output) {
-    return "";
-  }
-
-  return truncateText(output, TOOL_OUTPUT_LIMIT);
+  return sanitizeConversationBody(text, role);
 }
 
 function buildFallbackTimeline(session) {
   return (session.historyPreview || [])
-    .map((text) => text.trim())
+    .map((text) => sanitizeConversationBody(text, "user"))
     .filter(Boolean)
     .map((body, index) => ({
       kind: "user",
@@ -2967,6 +3004,56 @@ function renderConversationItem(item) {
       <div class="conversation-body">${escapeHtml(item.body)}</div>
     </article>
   `;
+}
+
+function isRenderableTimelineItem(item) {
+  return (item.kind === "user" || item.kind === "assistant") && Boolean(item.body?.trim());
+}
+
+function sanitizeConversationBody(body, kind) {
+  const normalized = String(body || "").replace(/\r\n/g, "\n").trim();
+
+  if (!normalized) {
+    return "";
+  }
+
+  if (kind !== "user") {
+    return normalized;
+  }
+
+  const stripped = stripInjectedPromptMetadata(normalized);
+  return stripped === normalized ? normalized : stripped;
+}
+
+function stripInjectedPromptMetadata(text) {
+  const leadingBlockPatterns = [
+    /^# AGENTS\.md instructions for[^\n]*\n*/i,
+    /^<INSTRUCTIONS>[\s\S]*?<\/INSTRUCTIONS>\s*/i,
+    /^<environment_context>[\s\S]*?<\/environment_context>\s*/i,
+    /^<permissions instructions>[\s\S]*?<\/permissions instructions>\s*/i,
+    /^<collaboration_mode>[\s\S]*?<\/collaboration_mode>\s*/i,
+    /^<apps_instructions>[\s\S]*?<\/apps_instructions>\s*/i,
+    /^<skills_instructions>[\s\S]*?<\/skills_instructions>\s*/i,
+    /^<plugins_instructions>[\s\S]*?<\/plugins_instructions>\s*/i,
+  ];
+
+  let cleaned = text.trim();
+  let changed = true;
+
+  while (changed && cleaned) {
+    changed = false;
+
+    for (const pattern of leadingBlockPatterns) {
+      const next = cleaned.replace(pattern, "").trimStart();
+
+      if (next !== cleaned) {
+        cleaned = next;
+        changed = true;
+      }
+    }
+  }
+
+  return cleaned.trim();
 }
 
 function updateStatus() {
@@ -3610,14 +3697,6 @@ function buildSessionSummary(session) {
   }
 
   return session.relativePath || t("summary.none");
-}
-
-function truncateText(text, limit) {
-  if (text.length <= limit) {
-    return text;
-  }
-
-  return `${text.slice(0, limit)}...`;
 }
 
 function abbreviateId(id) {

--- a/index.html
+++ b/index.html
@@ -1049,6 +1049,21 @@ dd {
   gap: 10px;
 }
 
+.detail-head-stack {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.detail-inline-toggle {
+  justify-self: end;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-soft);
+}
+
 #detail-overview {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -1063,6 +1078,99 @@ dd {
 
 .conversation-stream {
   gap: 14px;
+}
+
+.question-outline {
+  display: grid;
+  gap: 8px;
+  max-height: 220px;
+  overflow-y: auto;
+  padding-right: 4px;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+.question-outline::-webkit-scrollbar {
+  width: 10px;
+}
+
+.question-outline::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+  border-radius: 999px;
+}
+
+.question-outline::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-thumb);
+  border-radius: 999px;
+  border: 2px solid var(--scrollbar-track);
+}
+
+.question-outline::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+}
+
+.outline-link {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-soft);
+  color: var(--text);
+  padding: 10px 12px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  text-align: left;
+  transition:
+    border-color 180ms ease,
+    background-color 180ms ease,
+    transform 180ms ease;
+}
+
+.outline-link:hover,
+.outline-link:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--border-strong);
+  background: var(--surface-strong);
+}
+
+.outline-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent), transparent 52%);
+  outline-offset: 2px;
+}
+
+.outline-index {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-strong);
+  color: var(--text-soft);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.outline-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.outline-title {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.45;
+}
+
+.outline-meta {
+  color: var(--text-faint);
+  font-size: 0.78rem;
 }
 
 .conversation-item {
@@ -1102,6 +1210,12 @@ dd {
   border-color: color-mix(in srgb, var(--accent), transparent 82%);
 }
 
+.conversation-item.reasoning {
+  margin-inline: clamp(14px, 4vw, 72px);
+  background: color-mix(in srgb, var(--warning-soft), var(--surface-strong) 32%);
+  border-color: color-mix(in srgb, var(--warning), transparent 70%);
+}
+
 .conversation-item.system {
   background: color-mix(in srgb, var(--surface-soft), transparent 15%);
 }
@@ -1112,6 +1226,10 @@ dd {
 
 .conversation-item.assistant::before {
   background: color-mix(in srgb, var(--accent), transparent 18%);
+}
+
+.conversation-item.reasoning::before {
+  background: var(--warning);
 }
 
 .conversation-meta {
@@ -1148,12 +1266,24 @@ dd {
   color: var(--text);
 }
 
+.conversation-item.reasoning .conversation-role {
+  background: color-mix(in srgb, var(--warning-soft), var(--surface-strong) 14%);
+  border-color: color-mix(in srgb, var(--warning), transparent 68%);
+  color: color-mix(in srgb, var(--warning), var(--text) 24%);
+}
+
 .conversation-body {
   color: var(--text);
   line-height: 1.7;
   font-size: 0.95rem;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.conversation-item.is-targeted {
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--info), transparent 68%),
+    var(--shadow);
 }
 
 .conversation-divider {
@@ -1495,7 +1625,8 @@ dd {
   }
 
   .conversation-item.user,
-  .conversation-item.assistant {
+  .conversation-item.assistant,
+  .conversation-item.reasoning {
     margin-left: 0;
     margin-right: 0;
   }
@@ -1718,24 +1849,42 @@ dd {
             </div>
           </div>
 
-          <div class="detail-scroll">
-            <div class="detail-block">
-              <dl id="detail-overview" class="meta-grid">
-                <div>
-                  <dt id="detail-overview-default-label">会话 ID</dt>
-                  <dd>-</dd>
-                </div>
-              </dl>
-            </div>
+	          <div class="detail-scroll">
+	            <div class="detail-block">
+	              <dl id="detail-overview" class="meta-grid">
+	                <div>
+	                  <dt id="detail-overview-default-label">会话 ID</dt>
+	                  <dd>-</dd>
+	                </div>
+	              </dl>
+	            </div>
 
-            <div class="detail-block">
-              <div class="section-head compact">
-                <h2 id="detail-preview-title" class="section-title">完整对话</h2>
-                <span id="detail-message-count" class="badge">0</span>
-              </div>
-              <div id="detail-preview" class="conversation-stream">
-                <p class="empty-state">暂无会话内容.</p>
-              </div>
+	            <div class="detail-block">
+	              <div class="section-head compact">
+	                <div class="detail-head-stack">
+	                  <h2 id="detail-outline-title" class="section-title">问题目录</h2>
+	                  <span id="detail-outline-count" class="badge">0</span>
+	                </div>
+	              </div>
+	              <div id="detail-outline" class="question-outline">
+	                <p class="empty-state">暂无用户提问.</p>
+	              </div>
+	            </div>
+
+	            <div class="detail-block">
+	              <div class="section-head compact">
+	                <div class="detail-head-stack">
+	                  <h2 id="detail-preview-title" class="section-title">完整对话</h2>
+	                  <span id="detail-message-count" class="badge">0</span>
+	                </div>
+	                <label class="checkbox-row detail-inline-toggle">
+	                  <input id="reasoning-toggle" type="checkbox" />
+	                  <span id="reasoning-toggle-label">显示思考摘要</span>
+	                </label>
+	              </div>
+	              <div id="detail-preview" class="conversation-stream">
+	                <p class="empty-state">暂无会话内容.</p>
+	              </div>
             </div>
 
             <div class="detail-block legacy-session-block" hidden aria-hidden="true">
@@ -1852,6 +2001,7 @@ dd {
     <script type="module">
 const THEME_STORAGE_KEY = "codex-session-console-theme";
 const LOCALE_STORAGE_KEY = "codex-session-console-locale";
+const REASONING_VISIBILITY_STORAGE_KEY = "codex-session-console-show-reasoning";
 const REPOSITORY_URL = "https://github.com/zhengshuyun-com/codex-local-session-manager";
 
 const I18N = {
@@ -1870,6 +2020,7 @@ const I18N = {
       metrics: "统计",
       list: "会话列表",
       detail: "详情",
+      questions: "问题目录",
       conversation: "完整对话",
     },
     labels: {
@@ -1942,10 +2093,12 @@ const I18N = {
       unselectedCaption: "未选择会话",
       unselectedTitle: "未选择会话",
       noContent: "暂无会话内容.",
+      noQuestions: "暂无用户提问.",
       noRenderableContent: "没有可展示的会话内容.",
       loading: "加载中.",
       statusNormal: "正常",
       statusStale: "脏索引",
+      showReasoning: "显示思考摘要",
     },
     modal: {
       titleAll: "确认删除全部会话",
@@ -1984,6 +2137,7 @@ const I18N = {
     timeline: {
       user: "用户",
       assistant: "Codex",
+      reasoning: "思考摘要",
       toolCall: "工具调用",
       toolOutput: "工具输出",
       historyInput: "历史输入 #{{index}}",
@@ -2019,6 +2173,7 @@ const I18N = {
       metrics: "Stats",
       list: "Sessions",
       detail: "Details",
+      questions: "Question Outline",
       conversation: "Conversation",
     },
     labels: {
@@ -2091,10 +2246,12 @@ const I18N = {
       unselectedCaption: "No session selected",
       unselectedTitle: "No session selected",
       noContent: "No session content yet.",
+      noQuestions: "No user questions yet.",
       noRenderableContent: "No conversation content available.",
       loading: "Loading.",
       statusNormal: "Normal",
       statusStale: "Stale index",
+      showReasoning: "Show reasoning summaries",
     },
     modal: {
       titleAll: "Confirm delete all sessions",
@@ -2134,6 +2291,7 @@ const I18N = {
     timeline: {
       user: "User",
       assistant: "Codex",
+      reasoning: "Reasoning Summary",
       toolCall: "Tool call",
       toolOutput: "Tool output",
       historyInput: "History input #{{index}}",
@@ -2171,11 +2329,13 @@ const state = {
   pageSize: 10,
   locale: "zh-CN",
   themeMode: "light",
+  showReasoning: false,
   modalKind: null,
   pendingActionMode: null,
   countdownRemaining: 0,
   countdownTimer: null,
   previewRequestId: 0,
+  activeHighlightTimer: null,
 };
 
 const elements = {
@@ -2207,9 +2367,14 @@ const elements = {
   sessionList: document.querySelector("#session-list"),
   detailCaption: document.querySelector("#detail-caption"),
   detailOverview: document.querySelector("#detail-overview"),
+  detailOutlineTitle: document.querySelector("#detail-outline-title"),
+  detailOutline: document.querySelector("#detail-outline"),
+  detailOutlineCount: document.querySelector("#detail-outline-count"),
   detailPreviewTitle: document.querySelector("#detail-preview-title"),
   detailPreview: document.querySelector("#detail-preview"),
   detailMessageCount: document.querySelector("#detail-message-count"),
+  reasoningToggle: document.querySelector("#reasoning-toggle"),
+  reasoningToggleLabel: document.querySelector("#reasoning-toggle-label"),
   downloadCurrentButton: document.querySelector("#download-current-button"),
   deleteCurrentButton: document.querySelector("#delete-current-button"),
   repoLink: document.querySelector("#repo-link"),
@@ -2250,6 +2415,8 @@ function initialize() {
   elements.pageSizeSelect.addEventListener("change", handlePageSizeChange);
   elements.prevPageButton.addEventListener("click", () => changePage(-1));
   elements.nextPageButton.addEventListener("click", () => changePage(1));
+  elements.detailOutline.addEventListener("click", handleOutlineJump);
+  elements.reasoningToggle.addEventListener("change", handleReasoningToggleChange);
   elements.downloadCurrentButton.addEventListener("click", () => downloadCurrentSession().catch(handleError));
   elements.deleteCurrentButton.addEventListener("click", () => openConfirmDialog("single"));
   elements.modalBackdrop.addEventListener("click", handleModalDismiss);
@@ -2260,6 +2427,7 @@ function initialize() {
 
   applyLocale(getInitialLocale());
   applyTheme(getInitialThemeMode());
+  applyReasoningVisibility(getInitialReasoningVisibility(), { rerender: false });
   renderEmptyList(t("list.unscanned"));
   renderDetails(null);
   updateStatus();
@@ -2481,6 +2649,33 @@ function changePage(offset) {
   updateStatus();
 }
 
+function handleReasoningToggleChange() {
+  applyReasoningVisibility(elements.reasoningToggle.checked);
+}
+
+function applyReasoningVisibility(visible, { rerender = true } = {}) {
+  state.showReasoning = Boolean(visible);
+  localStorage.setItem(REASONING_VISIBILITY_STORAGE_KEY, state.showReasoning ? "1" : "0");
+  elements.reasoningToggle.checked = state.showReasoning;
+
+  if (!rerender) {
+    return;
+  }
+
+  const activeSession = getActiveSession();
+
+  if (!activeSession) {
+    renderDetails(null);
+    return;
+  }
+
+  renderTimelinePanels(activeSession).catch(handleError);
+}
+
+function getInitialReasoningVisibility() {
+  return localStorage.getItem(REASONING_VISIBILITY_STORAGE_KEY) === "1";
+}
+
 function applyFilters() {
   const query = elements.searchInput.value.trim().toLowerCase();
   const age = elements.ageFilter.value;
@@ -2616,6 +2811,50 @@ function renderList() {
   elements.sessionList.appendChild(fragment);
 }
 
+function handleOutlineJump(event) {
+  const button = event.target.closest("[data-anchor-id]");
+
+  if (!button) {
+    return;
+  }
+
+  jumpToTimelineAnchor(button.dataset.anchorId || "");
+}
+
+function jumpToTimelineAnchor(anchorId) {
+  if (!anchorId) {
+    return;
+  }
+
+  const target = document.getElementById(anchorId);
+
+  if (!target || !elements.detailPreview.contains(target)) {
+    return;
+  }
+
+  target.scrollIntoView({
+    behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+    block: "center",
+    inline: "nearest",
+  });
+
+  clearActiveConversationTarget();
+  target.classList.add("is-targeted");
+  state.activeHighlightTimer = window.setTimeout(() => {
+    target.classList.remove("is-targeted");
+    state.activeHighlightTimer = null;
+  }, 1800);
+}
+
+function clearActiveConversationTarget() {
+  if (state.activeHighlightTimer) {
+    window.clearTimeout(state.activeHighlightTimer);
+    state.activeHighlightTimer = null;
+  }
+
+  elements.detailPreview.querySelector(".conversation-item.is-targeted")?.classList.remove("is-targeted");
+}
+
 function createListItemNode() {
   const templateNode = elements.template?.content?.firstElementChild;
 
@@ -2648,6 +2887,7 @@ function createListItemNode() {
 
 function renderDetails(session) {
   state.previewRequestId += 1;
+  clearActiveConversationTarget();
 
   if (!session) {
     elements.detailCaption.textContent = t("detail.unselectedCaption");
@@ -2657,9 +2897,13 @@ function renderDetails(session) {
       makeOverviewItem(t("labels.updatedAt"), "-"),
       makeOverviewItem(t("labels.status"), "-"),
     ].join("");
+    elements.detailOutlineTitle.textContent = t("section.questions");
+    setBadgeText(elements.detailOutlineCount, "0");
+    elements.detailOutline.innerHTML = `<p class="empty-state">${escapeHtml(t("detail.noQuestions"))}</p>`;
     elements.detailPreviewTitle.textContent = t("section.conversation");
     setBadgeText(elements.detailMessageCount, "0");
     elements.detailPreview.innerHTML = `<p class="empty-state">${escapeHtml(t("detail.noContent"))}</p>`;
+    elements.reasoningToggle.disabled = true;
     elements.downloadCurrentButton.disabled = true;
     elements.downloadCurrentButton.textContent = t("buttons.download");
     elements.deleteCurrentButton.disabled = true;
@@ -2674,13 +2918,15 @@ function renderDetails(session) {
     makeOverviewItem(t("labels.updatedAt"), formatDateTime(session.updatedAt)),
     makeOverviewItem(t("labels.status"), session.stale ? t("detail.statusStale") : t("detail.statusNormal")),
   ].join("");
+  elements.detailOutlineTitle.textContent = t("section.questions");
   elements.detailPreviewTitle.textContent = t("section.conversation");
+  elements.reasoningToggle.disabled = false;
   elements.downloadCurrentButton.disabled = !isSessionDownloadable(session);
   elements.downloadCurrentButton.textContent = t("buttons.download");
   elements.deleteCurrentButton.disabled = !isSessionDeletable(session);
   elements.deleteCurrentButton.textContent = t("buttons.delete");
 
-  renderTimeline(session).catch(handleError);
+  renderTimelinePanels(session).catch(handleError);
 }
 
 async function downloadCurrentSession() {
@@ -2705,8 +2951,10 @@ async function downloadCurrentSession() {
   }, 0);
 }
 
-async function renderTimeline(session) {
+async function renderTimelinePanels(session) {
   const requestId = ++state.previewRequestId;
+  clearActiveConversationTarget();
+  elements.detailOutline.innerHTML = `<p class="empty-state">${escapeHtml(t("detail.loading"))}</p>`;
   elements.detailPreview.innerHTML = `<p class="empty-state">${escapeHtml(t("detail.loading"))}</p>`;
 
   const timeline = await getSessionTimeline(session);
@@ -2715,14 +2963,17 @@ async function renderTimeline(session) {
     return;
   }
 
-  setBadgeText(elements.detailMessageCount, String(timeline.length));
+  renderQuestionOutline(timeline);
 
-  if (!timeline.length) {
+  const visibleTimeline = getVisibleTimelineItems(timeline);
+  setBadgeText(elements.detailMessageCount, String(visibleTimeline.length));
+
+  if (!visibleTimeline.length) {
     elements.detailPreview.innerHTML = `<p class="empty-state">${escapeHtml(t("detail.noRenderableContent"))}</p>`;
     return;
   }
 
-  elements.detailPreview.innerHTML = timeline.map(renderConversationItem).join("");
+  elements.detailPreview.innerHTML = visibleTimeline.map(renderConversationItem).join("");
 }
 
 async function getSessionTimeline(session) {
@@ -2769,9 +3020,11 @@ async function getSessionTimeline(session) {
     }
   }
 
-  const timeline = items.length
-    ? dedupePreviewTimeline(items).map(stripTimelineMeta).filter(isRenderableTimelineItem)
-    : buildFallbackTimeline(session);
+  const timeline = finalizeTimeline(
+    (items.length ? dedupePreviewTimeline(items).map(stripTimelineMeta) : buildFallbackTimeline(session)).filter(
+      isRenderableTimelineItem,
+    ),
+  );
   state.timelineCache.set(session.id, timeline);
   return timeline;
 }
@@ -2954,6 +3207,21 @@ function extractResponseItems(record) {
     ];
   }
 
+  if (payload.type === "reasoning") {
+    const body = extractReasoningSummary(payload);
+
+    return body
+      ? [
+          {
+            kind: "reasoning",
+            roleLabel: t("timeline.reasoning"),
+            timestamp,
+            body,
+          },
+        ]
+      : [];
+  }
+
   return [];
 }
 
@@ -2982,6 +3250,39 @@ function extractMessageContent(content, role = "") {
   return sanitizeConversationBody(text, role);
 }
 
+function extractReasoningSummary(payload) {
+  const summary = Array.isArray(payload.summary) ? payload.summary : [];
+  const summaryText = summary
+    .map((item) => {
+      if (item?.type === "summary_text") {
+        return item.text || "";
+      }
+
+      return typeof item === "string" ? item : "";
+    })
+    .map((text) => normalizeReasoningSummaryText(text))
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+
+  if (summaryText) {
+    return summaryText;
+  }
+
+  if (Array.isArray(payload.content)) {
+    return normalizeReasoningSummaryText(extractMessageContent(payload.content, "assistant"));
+  }
+
+  return "";
+}
+
+function normalizeReasoningSummaryText(text) {
+  return String(text || "")
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/__(.*?)__/g, "$1")
+    .trim();
+}
+
 function buildFallbackTimeline(session) {
   return (session.historyPreview || [])
     .map((text) => sanitizeConversationBody(text, "user"))
@@ -2996,7 +3297,7 @@ function buildFallbackTimeline(session) {
 
 function renderConversationItem(item) {
   return `
-    <article class="conversation-item ${escapeHtml(item.kind)}">
+    <article id="${escapeHtml(item.anchorId)}" class="conversation-item ${escapeHtml(item.kind)}">
       <div class="conversation-meta">
         <span class="conversation-role">${escapeHtml(item.roleLabel)}</span>
         <span>${escapeHtml(formatDateTime(item.timestamp))}</span>
@@ -3006,8 +3307,63 @@ function renderConversationItem(item) {
   `;
 }
 
+function renderQuestionOutline(timeline) {
+  const questions = timeline.filter((item) => item.kind === "user");
+  setBadgeText(elements.detailOutlineCount, String(questions.length));
+
+  if (!questions.length) {
+    elements.detailOutline.innerHTML = `<p class="empty-state">${escapeHtml(t("detail.noQuestions"))}</p>`;
+    return;
+  }
+
+  elements.detailOutline.innerHTML = questions.map(renderQuestionOutlineItem).join("");
+}
+
+function renderQuestionOutlineItem(item) {
+  return `
+    <button class="outline-link" type="button" data-anchor-id="${escapeHtml(item.anchorId)}">
+      <span class="outline-index">Q${escapeHtml(item.questionNumber)}</span>
+      <span class="outline-copy">
+        <strong class="outline-title">${escapeHtml(getOutlineTitle(item.body))}</strong>
+        <span class="outline-meta">${escapeHtml(formatDateTime(item.timestamp))}</span>
+      </span>
+    </button>
+  `;
+}
+
+function getVisibleTimelineItems(timeline) {
+  return timeline.filter((item) => item.kind !== "reasoning" || state.showReasoning);
+}
+
+function finalizeTimeline(items) {
+  let questionNumber = 0;
+
+  return items.map((item, index) => {
+    const normalized = {
+      ...item,
+      anchorId: `timeline-item-${index + 1}`,
+    };
+
+    if (item.kind === "user") {
+      questionNumber += 1;
+      normalized.questionNumber = questionNumber;
+    }
+
+    return normalized;
+  });
+}
+
+function getOutlineTitle(body) {
+  return (
+    String(body || "")
+      .split(/\n+/)
+      .map((line) => line.trim())
+      .find(Boolean) || body
+  );
+}
+
 function isRenderableTimelineItem(item) {
-  return (item.kind === "user" || item.kind === "assistant") && Boolean(item.body?.trim());
+  return ["user", "assistant", "reasoning"].includes(item.kind) && Boolean(item.body?.trim());
 }
 
 function sanitizeConversationBody(body, kind) {
@@ -3534,6 +3890,8 @@ function applyLocale(locale) {
   setText(document.querySelector("#page-size-label"), t("labels.pageSize"));
   setText(document.querySelector("#detail-section-title"), t("section.detail"));
   setText(document.querySelector("#detail-overview-default-label"), t("labels.sessionId"));
+  setText(elements.detailOutlineTitle, t("section.questions"));
+  setText(elements.reasoningToggleLabel, t("detail.showReasoning"));
   setText(elements.pickDirectoryButton, t("buttons.pickDirectory"));
   setText(elements.reloadButton, t("buttons.reload"));
   setText(elements.deleteSelectedButton, t("buttons.deleteSelected"));
@@ -3543,6 +3901,8 @@ function applyLocale(locale) {
   setText(elements.nextPageButton, t("buttons.nextPage"));
   setText(elements.downloadCurrentButton, t("buttons.download"));
   setText(elements.modalCancelButton, t("buttons.cancel"));
+  elements.reasoningToggle.setAttribute("aria-label", t("detail.showReasoning"));
+  elements.reasoningToggle.setAttribute("title", t("detail.showReasoning"));
   elements.repoLink.setAttribute("aria-label", t("buttons.repository"));
   elements.repoLink.setAttribute("title", t("buttons.repository"));
 
@@ -3783,11 +4143,14 @@ function handleError(error) {
   console.error(error);
   closeModalDialog();
   state.previewRequestId += 1;
+  clearActiveConversationTarget();
   const message = error?.message || t("errors.unknown");
   elements.statusBadge.textContent = t("badge.error");
   setBadgeTone(elements.statusBadge, "danger");
   elements.statusText.textContent = message;
   renderEmptyList(message);
+  setBadgeText(elements.detailOutlineCount, "0");
+  elements.detailOutline.innerHTML = `<p class="empty-state">${escapeHtml(message)}</p>`;
   elements.detailPreview.innerHTML = `<p class="empty-state">${escapeHtml(message)}</p>`;
 }
 


### PR DESCRIPTION
1. 调整了会话列表与详情区域的布局比例
2. 优化滚动渲染表现
3. 增强用户提问与 Codex 回答的视觉区分
4. 同时过滤 skill / 系统注入类噪音，让对话内容更聚焦。
5. 新增“问题目录”，可以按用户提问快速定位并跳转到对应消息。
6. 补上对 Codex 过程消息的识别与按需显示能力，默认只看最终回答。
7. 记住上次打开的 .codex 目录，在权限仍有效时自动恢复，减少重复选择目录的操作。